### PR TITLE
fix(utils): fallback to stdlib json when ujson is unavailable

### DIFF
--- a/flet_asp/utils.py
+++ b/flet_asp/utils.py
@@ -1,5 +1,9 @@
-import ujson
 from typing import Any
+
+try:
+    import ujson as json
+except ImportError:
+    import json
 
 
 def deep_equal(a: Any, b: Any) -> bool:
@@ -20,6 +24,8 @@ def deep_equal(a: Any, b: Any) -> bool:
     """
 
     try:
-        return ujson.dumps(a, sort_keys=True) == ujson.dumps(b, sort_keys=True)
-    except (TypeError, OverflowError):
+        sa = json.dumps(a, sort_keys=True)
+        sb = json.dumps(b, sort_keys=True)
+        return sa == sb
+    except (TypeError, OverflowError, ValueError):
         return a == b


### PR DESCRIPTION
@Arya2255 reported installation failures when using Codespaces in an ARM64 environment.
The error occurred because there was no pre-built wheel available for `ujson>=5.10.0`:

> ERROR: Could not find a version that satisfies the requirement ujson>=5.10.0
> ERROR: No matching distribution found for ujson>=5.10.0

This issue was also shared on Discord along with a screenshot showing the failure:

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/037d0746-b4df-47b2-bf19-ab8a04a31aa9" />


## What has changed
- Updated the JSON import logic to:
  - Prefer `ujson` for better performance.
  - Fall back to Python's built-in `json` module automatically when `ujson` is not available.
- Removed the hard dependency on `ujson>=5.10.0` from `pyproject.toml`.
- Ensured that `deep_equal()` continues to work consistently regardless of which JSON module is available.

## Why this is needed
- Prevents installation errors in environments where no `ujson` wheels exist.
- Maintains performance benefits of `ujson` on platforms where it is available.
- Improves cross-platform compatibility (e.g., ARM64, Codespaces, CI environments).

## Additional notes
- No breaking API changes.
- Behavior remains identical when `ujson` is installed.
- If `ujson` is not present, the code gracefully uses the standard library's `json`.

Closes https://github.com/brunobrown/flet-asp/issues/6