### PR TITLE
Feature/add state alias

### DIFF
--- a/flet_asp/state.py
+++ b/flet_asp/state.py
@@ -307,8 +307,9 @@ def get_state_manager(page: Page) -> StateManager:
     Returns:
         StateManager: Unique manager instance for the page.
     """
-
     if not hasattr(page, "_state_manager"):
-        setattr(page, "_state_manager", StateManager())
+        manager = StateManager()
+        setattr(page, "_state_manager", manager)
+        setattr(page, "state", manager)
 
     return getattr(page, "_state_manager")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,8 @@ Issues = "https://github.com/brunobrown/flet-asp/issues"
 [tool.uv]
 dev-dependencies = [
     "flet[all]==0.25.2",
+    "pytest>=8.4.1",
 ]
-
-#[tool.setuptools]
-#packages = ["flet-asp"]
-#package-dir = {"" = "src"}
 
 [tool.setuptools.package-data]
 "flet_asp" = ["**/*"]

--- a/tests/test_state_alias.py
+++ b/tests/test_state_alias.py
@@ -1,0 +1,365 @@
+import pytest
+from flet_asp.state import StateManager, get_state_manager
+
+
+# Classe simples para simular ft.Page sem dependências externas
+# pytest tests/test_state_alias.py -v
+
+class MockPage:
+    """Mock simples para ft.Page que permite setattr/getattr"""
+    pass
+
+
+class TestStateAlias:
+    """
+    Testa se o alias 'state' funciona corretamente como alternativa ao '_state_manager'.
+    """
+
+    def test_state_alias_exists_after_get_state_manager(self):
+        """
+        Testa se o alias 'state' é criado após chamar get_state_manager.
+        """
+        mock_page = MockPage()
+
+        # Chama a função que deve criar o alias
+        manager = get_state_manager(mock_page)
+
+        # Verifica se tanto _state_manager quanto state existem
+        assert hasattr(mock_page, '_state_manager')
+        assert hasattr(mock_page, 'state')
+
+    def test_state_and_state_manager_are_same_instance(self):
+        """
+        Testa se 'state' e '_state_manager' apontam para a mesma instância.
+        """
+        mock_page = MockPage()
+
+        # Obtém o state manager
+        manager = get_state_manager(mock_page)
+
+        # Verifica se são a mesma instância
+        assert mock_page.state is mock_page._state_manager
+        assert id(mock_page.state) == id(mock_page._state_manager)
+
+    def test_state_alias_methods_work_correctly(self):
+        """
+        Testa se todos os métodos funcionam corretamente através do alias 'state'.
+        """
+        mock_page = MockPage()
+        get_state_manager(mock_page)
+
+        # Testa atom() via alias
+        counter_atom = mock_page.state.atom("counter", default=10)
+        assert counter_atom.value == 10
+
+        # Testa get() via alias
+        assert mock_page.state.get("counter") == 10
+
+        # Testa set() via alias
+        mock_page.state.set("counter", 25)
+        assert mock_page.state.get("counter") == 25
+
+    def test_backward_compatibility_maintained(self):
+        """
+        Testa se código existente usando '_state_manager' continua funcionando.
+        """
+        mock_page = MockPage()
+        get_state_manager(mock_page)
+
+        # Usa a forma tradicional
+        mock_page._state_manager.atom("user", default="guest")
+        mock_page._state_manager.set("user", "admin")
+
+        # Verifica se funciona e se o alias também vê a mudança
+        assert mock_page._state_manager.get("user") == "admin"
+        assert mock_page.state.get("user") == "admin"
+
+    def test_both_interfaces_modify_same_state(self):
+        """
+        Testa se mudanças feitas via 'state' são visíveis via '_state_manager' e vice-versa.
+        """
+        mock_page = MockPage()
+        get_state_manager(mock_page)
+
+        # Cria átomo via state alias
+        mock_page.state.atom("theme", default="light")
+
+        # Modifica via _state_manager
+        mock_page._state_manager.set("theme", "dark")
+
+        # Verifica via state alias
+        assert mock_page.state.get("theme") == "dark"
+
+        # Modifica via state alias
+        mock_page.state.set("theme", "auto")
+
+        # Verifica via _state_manager
+        assert mock_page._state_manager.get("theme") == "auto"
+
+    def test_complex_operations_work_with_alias(self):
+        """
+        Testa operações mais complexas como selectors e listeners via alias.
+        """
+        mock_page = MockPage()
+        get_state_manager(mock_page)
+
+        # Cria átomos
+        mock_page.state.atom("first_name", default="João")
+        mock_page.state.atom("last_name", default="Silva")
+
+        # Cria selector via alias
+        @mock_page.state.selector("full_name")
+        def full_name(get):
+            return f"{get('first_name')} {get('last_name')}"
+
+        # Testa se o selector funciona
+        assert mock_page.state.get("full_name") == "João Silva"
+
+        # Testa listener via alias
+        callback_called = []
+        def on_name_change(value):
+            callback_called.append(value)
+
+        mock_page.state.listen("first_name", on_name_change, immediate=False)
+        mock_page.state.set("first_name", "Pedro")
+
+        assert callback_called == ["Pedro"]
+
+    def test_get_state_manager_called_multiple_times(self):
+        """
+        Testa se chamar get_state_manager múltiplas vezes não quebra o alias.
+        """
+        mock_page = MockPage()
+
+        # Primeira chamada
+        manager1 = get_state_manager(mock_page)
+        first_state = mock_page.state
+
+        # Segunda chamada
+        manager2 = get_state_manager(mock_page)
+        second_state = mock_page.state
+
+        # Devem ser as mesmas instâncias
+        assert manager1 is manager2
+        assert first_state is second_state
+        assert mock_page.state is mock_page._state_manager
+
+    def test_alias_preserves_all_state_manager_methods(self):
+        """
+        Testa se o alias preserva todos os métodos importantes do StateManager.
+        """
+        mock_page = MockPage()
+        get_state_manager(mock_page)
+
+        # Lista de métodos que devem estar disponíveis via alias
+        expected_methods = [
+            'atom', 'get', 'set', 'has', 'reset', 'delete', 'clear',
+            'listen', 'unlisten', 'bind', 'unbind', 'add_selector',
+            'selector', 'invalidate', 'listen_multiple', 'bind_dynamic',
+            'bind_two_way'
+        ]
+
+        for method_name in expected_methods:
+            assert hasattr(mock_page.state, method_name)
+            assert callable(getattr(mock_page.state, method_name))
+
+    def test_error_handling_works_with_alias(self):
+        """
+        Testa se o tratamento de erros funciona corretamente via alias.
+        """
+        mock_page = MockPage()
+        get_state_manager(mock_page)
+
+        # Cria um selector
+        mock_page.state.add_selector("test_selector", lambda get: "computed")
+
+        # Tenta criar átomo com mesmo nome - deve dar erro
+        with pytest.raises(ValueError, match="Key 'test_selector' is already registered as a Selector"):
+            mock_page.state.atom("test_selector")
+
+
+# Testes de integração mais simples
+class TestStateAliasIntegration:
+    """
+    Testa cenários mais realistas de uso do alias.
+    """
+
+    def test_navigation_example_with_alias(self):
+        """
+        Simula o caso de uso mencionado na issue (navegação SPA).
+        """
+        mock_page = MockPage()
+        get_state_manager(mock_page)
+
+        # Simula configuração de navegação
+        mock_page.state.atom("current_page", default="/home")
+        mock_page.state.atom("navigation_stack", default=[])
+
+        # Simula action de navegação
+        def go_to_page(new_page):
+            current = mock_page.state.get("current_page")
+            stack = mock_page.state.get("navigation_stack")
+
+            # Adiciona página atual ao stack
+            mock_page.state.set("navigation_stack", stack + [current])
+            mock_page.state.set("current_page", new_page)
+
+        def go_back():
+            stack = mock_page.state.get("navigation_stack")
+            if stack:
+                previous_page = stack.pop()
+                mock_page.state.set("navigation_stack", stack)
+                mock_page.state.set("current_page", previous_page)
+
+        # Testa navegação
+        go_to_page("/grid/clientes")
+        assert mock_page.state.get("current_page") == "/grid/clientes"
+        assert mock_page.state.get("navigation_stack") == ["/home"]
+
+        go_to_page("/grid/clientes/form")
+        assert mock_page.state.get("current_page") == "/grid/clientes/form"
+        assert mock_page.state.get("navigation_stack") == ["/home", "/grid/clientes"]
+
+        # Testa voltar
+        go_back()
+        assert mock_page.state.get("current_page") == "/grid/clientes"
+        assert mock_page.state.get("navigation_stack") == ["/home"]
+
+    def test_multiple_pages_dont_interfere(self):
+        """
+        Testa se múltiplas páginas têm StateManagers independentes.
+        """
+        page1 = MockPage()
+        page2 = MockPage()
+
+        # Cria state managers para cada página
+        manager1 = get_state_manager(page1)
+        manager2 = get_state_manager(page2)
+
+        # Devem ser instâncias diferentes
+        assert manager1 is not manager2
+        assert page1.state is not page2.state
+
+        # Configurações independentes
+        page1.state.atom("theme", default="dark")
+        page2.state.atom("theme", default="light")
+
+        assert page1.state.get("theme") == "dark"
+        assert page2.state.get("theme") == "light"
+
+        # Mudança em uma não afeta a outra
+        page1.state.set("theme", "auto")
+        assert page1.state.get("theme") == "auto"
+        assert page2.state.get("theme") == "light"  # Não mudou
+
+    def test_real_world_form_state_management(self):
+        """
+        Simula um caso de uso real: gerenciamento de estado de formulário.
+        """
+        mock_page = MockPage()
+        get_state_manager(mock_page)
+
+        # Estado do formulário
+        mock_page.state.atom("form_data", default={
+            "name": "",
+            "email": "",
+            "age": 0
+        })
+        mock_page.state.atom("form_errors", default={})
+        mock_page.state.atom("form_loading", default=False)
+
+        # Selector para validação
+        @mock_page.state.selector("form_is_valid")
+        def form_is_valid(get):
+            data = get("form_data")
+            return (
+                len(data["name"]) > 0 and
+                "@" in data["email"] and
+                data["age"] > 0
+            )
+
+        # Estado inicial
+        assert not mock_page.state.get("form_is_valid")
+
+        # Preenche formulário
+        mock_page.state.set("form_data", {
+            "name": "João Silva",
+            "email": "joao@email.com",
+            "age": 30
+        })
+
+        # Agora deve ser válido
+        assert mock_page.state.get("form_is_valid")
+
+        # Testa estado de loading
+        mock_page.state.set("form_loading", True)
+        assert mock_page.state.get("form_loading")
+
+
+# Testes específicos para edge cases
+class TestStateAliasEdgeCases:
+    """
+    Testa casos especiais e edge cases.
+    """
+
+    def test_page_already_has_state_attribute(self):
+        """
+        Testa o que acontece se a página já tiver um atributo 'state'.
+        """
+        mock_page = MockPage()
+        # Simula página que já tem 'state'
+        mock_page.state = "existing_value"
+
+        # Chama get_state_manager
+        manager = get_state_manager(mock_page)
+
+        # O alias deve sobrescrever o valor existente
+        assert mock_page.state is not "existing_value"
+        assert mock_page.state is mock_page._state_manager
+        assert isinstance(mock_page.state, StateManager)
+
+    def test_page_methods_work_after_get_state_manager(self):
+        """
+        Testa se os métodos da página continuam funcionando após adicionar o alias.
+        """
+        class PageWithMethods(MockPage):
+            def custom_method(self):
+                return "page_method_result"
+
+        mock_page = PageWithMethods()
+        get_state_manager(mock_page)
+
+        # Método da página deve continuar funcionando
+        assert mock_page.custom_method() == "page_method_result"
+
+        # Alias state também deve funcionar
+        assert hasattr(mock_page, 'state')
+        assert isinstance(mock_page.state, StateManager)
+
+    def test_state_manager_functionality_not_affected(self):
+        """
+        Testa se toda a funcionalidade do StateManager permanece intacta.
+        """
+        mock_page = MockPage()
+        get_state_manager(mock_page)
+
+        # Testa funcionalidades avançadas
+        mock_page.state.atom("counter", default=0)
+
+        # Listen com callback
+        results = []
+        def callback(value):
+            results.append(value)
+
+        mock_page.state.listen("counter", callback, immediate=True)
+        assert results == [0]  # Immediate=True deve chamar com valor atual
+
+        # Múltiplas mudanças
+        mock_page.state.set("counter", 5)
+        mock_page.state.set("counter", 10)
+        assert results == [0, 5, 10]
+
+        # Reset
+        mock_page.state.reset("counter", 0)
+        assert mock_page.state.get("counter") == 0
+        assert results == [0, 5, 10, 0]

--- a/tests/test_state_basic.py
+++ b/tests/test_state_basic.py
@@ -1,0 +1,40 @@
+# e:/.../flet-asp/tests/test_state.py
+
+import pytest
+from flet_asp.state import StateManager
+
+def test_atom_creation_and_retrieval():
+    """
+    Tests if an atom can be created and its value retrieved correctly.
+    """
+    manager = StateManager()
+
+    # Cria um novo átomo com um valor padrão
+    counter_atom = manager.atom("counter", default=0)
+
+    # Verifica se o valor inicial está correto
+    assert manager.get("counter") == 0
+    assert counter_atom.value == 0
+
+def test_atom_update():
+    """
+    Tests if an atom's value can be updated using the set method.
+    """
+    manager = StateManager()
+    manager.atom("user", default="Guest")
+
+    # Atualiza o valor do átomo
+    manager.set("user", "Gemini")
+
+    # Verifica se o valor foi atualizado
+    assert manager.get("user") == "Gemini"
+
+def test_creating_atom_with_selector_key_raises_error():
+    """
+    Tests that creating an atom with a key already used by a selector raises a ValueError.
+    """
+    manager = StateManager()
+    manager.add_selector("my_selector", lambda get: "hello")
+
+    with pytest.raises(ValueError, match="Key 'my_selector' is already registered as a Selector."):
+        manager.atom("my_selector")

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -255,7 +255,7 @@ all = [
 
 [[package]]
 name = "flet-asp"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "flet" },
@@ -264,13 +264,17 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "flet", extra = ["all"] },
+    { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [{ name = "flet", specifier = ">=0.25.2" }]
 
 [package.metadata.requires-dev]
-dev = [{ name = "flet", extras = ["all"], specifier = "==0.25.2" }]
+dev = [
+    { name = "flet", extras = ["all"], specifier = "==0.25.2" },
+    { name = "pytest", specifier = ">=8.4.1" },
+]
 
 [[package]]
 name = "flet-cli"
@@ -420,6 +424,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -536,6 +549,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -678,6 +700,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/93/cd/112f092ec27cca83e0516de0a3368dbd9128c187fb6b52aaaa7cde39c96d/pypng-0.20220715.0.tar.gz", hash = "sha256:739c433ba96f078315de54c0db975aee537cbc3e1d0ae4ed9aab0ca1e427e2c1", size = 128992, upload-time = "2022-07-15T14:11:05.301Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/b9/3766cc361d93edb2ce81e2e1f87dd98f314d7d513877a342d31b30741680/pypng-0.20220715.0-py3-none-any.whl", hash = "sha256:4a43e969b8f5aaafb2a415536c1a8ec7e341cd6a3f957fd5b5f32a4cfeed902c", size = 58057, upload-time = "2022-07-15T14:11:03.713Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474, upload-time = "2025-06-18T05:48:03.955Z" },
 ]
 
 [[package]]
@@ -868,6 +908,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz", hash = "sha256:cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff", size = 17175, upload-time = "2024-11-27T22:38:36.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ca/75707e6efa2b37c77dadb324ae7d9571cb424e61ea73fad7c56c2d14527f/tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249", size = 131077, upload-time = "2024-11-27T22:37:54.956Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/16/51ae563a8615d472fdbffc43a3f3d46588c264ac4f024f63f01283becfbb/tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6", size = 123429, upload-time = "2024-11-27T22:37:56.698Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/dd/4f6cd1e7b160041db83c694abc78e100473c15d54620083dbd5aae7b990e/tomli-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a", size = 226067, upload-time = "2024-11-27T22:37:57.63Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6b/c54ede5dc70d648cc6361eaf429304b02f2871a345bbdd51e993d6cdf550/tomli-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6972ca9c9cc9f0acaa56a8ca1ff51e7af152a9f87fb64623e31d5c83700080ee", size = 236030, upload-time = "2024-11-27T22:37:59.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/47/999514fa49cfaf7a92c805a86c3c43f4215621855d151b61c602abb38091/tomli-2.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c954d2250168d28797dd4e3ac5cf812a406cd5a92674ee4c8f123c889786aa8e", size = 240898, upload-time = "2024-11-27T22:38:00.429Z" },
+    { url = "https://files.pythonhosted.org/packages/73/41/0a01279a7ae09ee1573b423318e7934674ce06eb33f50936655071d81a24/tomli-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:8dd28b3e155b80f4d54beb40a441d366adcfe740969820caf156c019fb5c7ec4", size = 229894, upload-time = "2024-11-27T22:38:02.094Z" },
+    { url = "https://files.pythonhosted.org/packages/55/18/5d8bc5b0a0362311ce4d18830a5d28943667599a60d20118074ea1b01bb7/tomli-2.2.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e59e304978767a54663af13c07b3d1af22ddee3bb2fb0618ca1593e4f593a106", size = 245319, upload-time = "2024-11-27T22:38:03.206Z" },
+    { url = "https://files.pythonhosted.org/packages/92/a3/7ade0576d17f3cdf5ff44d61390d4b3febb8a9fc2b480c75c47ea048c646/tomli-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:33580bccab0338d00994d7f16f4c4ec25b776af3ffaac1ed74e0b3fc95e885a8", size = 238273, upload-time = "2024-11-27T22:38:04.217Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6f/fa64ef058ac1446a1e51110c375339b3ec6be245af9d14c87c4a6412dd32/tomli-2.2.1-cp311-cp311-win32.whl", hash = "sha256:465af0e0875402f1d226519c9904f37254b3045fc5084697cefb9bdde1ff99ff", size = 98310, upload-time = "2024-11-27T22:38:05.908Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1c/4a2dcde4a51b81be3530565e92eda625d94dafb46dbeb15069df4caffc34/tomli-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:2d0f2fdd22b02c6d81637a3c95f8cd77f995846af7414c5c4b8d0545afa1bc4b", size = 108309, upload-time = "2024-11-27T22:38:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/52/e1/f8af4c2fcde17500422858155aeb0d7e93477a0d59a98e56cbfe75070fd0/tomli-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4a8f6e44de52d5e6c657c9fe83b562f5f4256d8ebbfe4ff922c495620a7f6cea", size = 132762, upload-time = "2024-11-27T22:38:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b8/152c68bb84fc00396b83e7bbddd5ec0bd3dd409db4195e2a9b3e398ad2e3/tomli-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8d57ca8095a641b8237d5b079147646153d22552f1c637fd3ba7f4b0b29167a8", size = 123453, upload-time = "2024-11-27T22:38:09.384Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/d6/fc9267af9166f79ac528ff7e8c55c8181ded34eb4b0e93daa767b8841573/tomli-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e340144ad7ae1533cb897d406382b4b6fede8890a03738ff1683af800d54192", size = 233486, upload-time = "2024-11-27T22:38:10.329Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/51c3f2884d7bab89af25f678447ea7d297b53b5a3b5730a7cb2ef6069f07/tomli-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db2b95f9de79181805df90bedc5a5ab4c165e6ec3fe99f970d0e302f384ad222", size = 242349, upload-time = "2024-11-27T22:38:11.443Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/df/bfa89627d13a5cc22402e441e8a931ef2108403db390ff3345c05253935e/tomli-2.2.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40741994320b232529c802f8bc86da4e1aa9f413db394617b9a256ae0f9a7f77", size = 252159, upload-time = "2024-11-27T22:38:13.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6e/fa2b916dced65763a5168c6ccb91066f7639bdc88b48adda990db10c8c0b/tomli-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:400e720fe168c0f8521520190686ef8ef033fb19fc493da09779e592861b78c6", size = 237243, upload-time = "2024-11-27T22:38:14.766Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/04/885d3b1f650e1153cbb93a6a9782c58a972b94ea4483ae4ac5cedd5e4a09/tomli-2.2.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:02abe224de6ae62c19f090f68da4e27b10af2b93213d36cf44e6e1c5abd19fdd", size = 259645, upload-time = "2024-11-27T22:38:15.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/de/6b432d66e986e501586da298e28ebeefd3edc2c780f3ad73d22566034239/tomli-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b82ebccc8c8a36f2094e969560a1b836758481f3dc360ce9a3277c65f374285e", size = 244584, upload-time = "2024-11-27T22:38:17.645Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9a/47c0449b98e6e7d1be6cbac02f93dd79003234ddc4aaab6ba07a9a7482e2/tomli-2.2.1-cp312-cp312-win32.whl", hash = "sha256:889f80ef92701b9dbb224e49ec87c645ce5df3fa2cc548664eb8a25e03127a98", size = 98875, upload-time = "2024-11-27T22:38:19.159Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/60/9b9638f081c6f1261e2688bd487625cd1e660d0a85bd469e91d8db969734/tomli-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7fc04e92e1d624a4a63c76474610238576942d6b8950a2d7f908a340494e67e4", size = 109418, upload-time = "2024-11-27T22:38:20.064Z" },
+    { url = "https://files.pythonhosted.org/packages/04/90/2ee5f2e0362cb8a0b6499dc44f4d7d48f8fff06d28ba46e6f1eaa61a1388/tomli-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7", size = 132708, upload-time = "2024-11-27T22:38:21.659Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/46b4108816de6b385141f082ba99e315501ccd0a2ea23db4a100dd3990ea/tomli-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:286f0ca2ffeeb5b9bd4fcc8d6c330534323ec51b2f52da063b11c502da16f30c", size = 123582, upload-time = "2024-11-27T22:38:22.693Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/bd/b470466d0137b37b68d24556c38a0cc819e8febe392d5b199dcd7f578365/tomli-2.2.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a92ef1a44547e894e2a17d24e7557a5e85a9e1d0048b0b5e7541f76c5032cb13", size = 232543, upload-time = "2024-11-27T22:38:24.367Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/82e80ff3b751373f7cead2815bcbe2d51c895b3c990686741a8e56ec42ab/tomli-2.2.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9316dc65bed1684c9a98ee68759ceaed29d229e985297003e494aa825ebb0281", size = 241691, upload-time = "2024-11-27T22:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/2a110bc2713557d6a1bfb06af23dd01e7dde52b6ee7dadc589868f9abfac/tomli-2.2.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272", size = 251170, upload-time = "2024-11-27T22:38:27.921Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/22d713946efe00e0adbcdfd6d1aa119ae03fd0b60ebed51ebb3fa9f5a2e5/tomli-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ac065718db92ca818f8d6141b5f66369833d4a80a9d74435a268c52bdfa73140", size = 236530, upload-time = "2024-11-27T22:38:29.591Z" },
+    { url = "https://files.pythonhosted.org/packages/38/31/3a76f67da4b0cf37b742ca76beaf819dca0ebef26d78fc794a576e08accf/tomli-2.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d920f33822747519673ee656a4b6ac33e382eca9d331c87770faa3eef562aeb2", size = 258666, upload-time = "2024-11-27T22:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/07/10/5af1293da642aded87e8a988753945d0cf7e00a9452d3911dd3bb354c9e2/tomli-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a198f10c4d1b1375d7687bc25294306e551bf1abfa4eace6650070a5c1ae2744", size = 243954, upload-time = "2024-11-27T22:38:31.702Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Descrição
Implementa alias `state` para `_state_manager` conforme discussão na issue #11.

## Mudanças
- ✅ Adiciona propriedade `state` como alias para `_state_manager`
- ✅ Mantém compatibilidade retroativa
- ✅ Inclui testes unitários
- ✅ Atualiza documentação (se aplicável)

## Testes
- [x] Testes passando
- [x] `page.state` e `page._state_manager` retornam mesma instância
- [x] Métodos `get`, `set`, `run` funcionam via `page.state`

## Checklist
- [x] Código segue padrões do projeto
- [x] Testes adicionados/atualizados
- [x] Documentação atualizada (se necessário)

Closes #11